### PR TITLE
Add extract support for RPA-3.2 archives.

### DIFF
--- a/rpatool
+++ b/rpatool
@@ -51,6 +51,7 @@ class RenPyArchive:
 
     RPA2_MAGIC = 'RPA-2.0 '
     RPA3_MAGIC = 'RPA-3.0 '
+    RPA3_2_MAGIC = 'RPA-3.2 '
 
     # For backward compatibility, otherwise Python3-packed archives won't be read by Python2
     PICKLE_PROTOCOL = 2
@@ -74,7 +75,9 @@ class RenPyArchive:
         self.handle.seek(0)
         magic = self.handle.readline().decode('utf-8')
 
-        if magic.startswith(self.RPA3_MAGIC):
+        if magic.startswith(self.RPA3_2_MAGIC):
+            return 3.2
+        elif magic.startswith(self.RPA3_MAGIC):
             return 3
         elif magic.startswith(self.RPA2_MAGIC):
             return 2
@@ -88,7 +91,7 @@ class RenPyArchive:
         self.handle.seek(0)
         indexes = None
 
-        if self.version == 2 or self.version == 3:
+        if self.version in [2, 3, 3.2]:
             # Fetch metadata.
             metadata = self.handle.readline()
             vals = metadata.split()
@@ -97,6 +100,10 @@ class RenPyArchive:
                 self.key = 0
                 for subkey in vals[2:]:
                     self.key ^= int(subkey, 16)
+            elif self.version == 3.2:
+                self.key = 0
+                for subkey in vals[3:]:
+                    self.key ^= int(subkey, 16)
 
             # Load in indexes.
             self.handle.seek(offset)
@@ -104,7 +111,7 @@ class RenPyArchive:
             indexes = _unpickle(contents)
 
             # Deobfuscate indexes.
-            if self.version == 3:
+            if self.version in [3, 3.2]:
                 obfuscated_indexes = indexes
                 indexes = {}
                 for i in obfuscated_indexes.keys():


### PR DESCRIPTION
rpatools failed to extract the .rpa files for [Zeliria Sanctuary](https://store.steampowered.com/app/855630/Zeliria_Sanctuary/) because it uses the RPA-3.2 format.

While looking at the metadata I noticed that the key has moved to the 4th value.

Metadata for Sattelite archive.rpa:
```python
vals:
['RPA-3.0', '0000000011e171a2', '42424242']
offset:
299987362
```

Metadata for Zeliria Sanctuary achive.rpa:
```python
vals:
['RPA-3.2', '000000000020a3b4', 'F', '42424240']
offset:
2139060
```

I haven't found any references to the RPA-3.2 format in the renpy source, which makes me suspect this is a customization by the game developer.

The changes in this PR allowed me to successfully extract the files from Zeliria Sanctuary .rpa files, and unpack its .rpyc files with unrpyc.