### PR TITLE
Update rpatool

### DIFF
--- a/rpatool
+++ b/rpatool
@@ -133,7 +133,7 @@ class RenPyArchive:
             padding += chr(random.randint(1, 255))
             length -= 1
 
-        return padding
+        return bytes(padding, 'utf-8')
 
     # Converts a filename to archive format.
     def convert_filename(self, filename):


### PR DESCRIPTION
Prevent crashing with "Could not save archive file: a bytes-like object is required, not 'str'"